### PR TITLE
fix(status-bar): Fix status bar numerical quota in 'used' mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1890,9 +1890,10 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
 
     // Build the base text components based on toggles
     const namePart = showName ? "Copilot: " : "";
+    const used = premiumQuota.entitlement - premiumQuota.remaining;
     const quotaPart = showNumericalQuota
       ? (progressBarMode === "used"
-        ? `${percentUsed}/${premiumQuota.entitlement}`
+        ? `${used}/${premiumQuota.entitlement}`
         : `${premiumQuota.remaining}/${premiumQuota.entitlement}`)
       : "";
 


### PR DESCRIPTION
# Fix status bar numerical quota in 'used' mode

## Description

This PR fixes a bug in the status bar display when `copilotInsights.progressBarMode` is set to `used`. Previously, the numerical quota incorrectly displayed the percentage of usage (e.g., `38/40`) instead of the actual count of used requests (e.g., `15/40`), making it inconsistent with the "remaining" mode.

## Changes

- Modified the `_formatStatusBarText` method in `src/extension.ts` to calculate and display the used count instead of percentage in "used" mode.

### Code Changes

**Before:**
```typescript
const quotaPart = showNumericalQuota
  ? (progressBarMode === "used"
    ? `${percentUsed}/${premiumQuota.entitlement}`
    : `${premiumQuota.remaining}/${premiumQuota.entitlement}`)
  : "";
```

**After:**
```typescript
const used = premiumQuota.entitlement - premiumQuota.remaining;
const quotaPart = showNumericalQuota
  ? (progressBarMode === "used"
    ? `${used}/${premiumQuota.entitlement}`
    : `${premiumQuota.remaining}/${premiumQuota.entitlement}`)
  : "";
```

## Testing

- Compiled the extension successfully.
- Installed and tested in VS Code.
- Verified that in "used" mode, the status bar now correctly shows the used count (e.g., `15/40`) instead of the percentage.

## Related

This fixes a regression introduced in PR #9 and will resolve BUG #10 