### PR TITLE
feat: fractional precision for usage count & percentage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-copilot-insights",
-  "version": "1.8.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-copilot-insights",
-      "version": "1.8.0",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
         {
           "type": "webview",
           "id": "copilotInsights.sidebarView",
-          "name": "Insights"
+          "name": "Insights",
+          "icon": "$(graph)"
         }
       ]
     },
@@ -173,7 +174,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "test-vsix": "vsce package && code --install-extension ./vscode-copilot-insights-*.vsix"
   },
   "devDependencies": {
     "@types/vscode": "^1.107.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,11 +293,9 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
     );
 
     if (premiumQuota && !premiumQuota.unlimited) {
-      const percentRemaining = Math.round(
-        (premiumQuota.remaining / premiumQuota.entitlement) * 100
-      );
-      const used = premiumQuota.entitlement - premiumQuota.remaining;
-      const percentUsed = Math.round((used / premiumQuota.entitlement) * 100);
+      const percentRemaining = parseFloat(((premiumQuota.quota_remaining / premiumQuota.entitlement) * 100).toFixed(1));
+      const used = premiumQuota.entitlement - premiumQuota.quota_remaining;
+      const percentUsed = parseFloat(((used / premiumQuota.entitlement) * 100).toFixed(1));
       const statusBadge = this._getStatusBadge(percentRemaining);
 
       // Get the configured style and toggles
@@ -372,11 +370,9 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
     );
 
     if (premiumQuota && !premiumQuota.unlimited) {
-      const percentRemaining = Math.round(
-        (premiumQuota.remaining / premiumQuota.entitlement) * 100
-      );
-      const used = premiumQuota.entitlement - premiumQuota.remaining;
-      const percentUsed = Math.round((used / premiumQuota.entitlement) * 100);
+      const percentRemaining = parseFloat(((premiumQuota.quota_remaining / premiumQuota.entitlement) * 100).toFixed(1));
+      const used = premiumQuota.entitlement - premiumQuota.quota_remaining;
+      const percentUsed = parseFloat(((used / premiumQuota.entitlement) * 100).toFixed(1));
 
       // Get the configured style
       const style = vscode.workspace
@@ -1262,11 +1258,10 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
 					`;
           }
 
-          const used = quota.entitlement - quota.remaining;
-          const percentUsed = Math.round((used / quota.entitlement) * 100);
-          const percentRemaining = Math.round(
-            (quota.remaining / quota.entitlement) * 100
-          );
+          const used = quota.entitlement - quota.quota_remaining;
+          const percentUsed = parseFloat(((used / quota.entitlement) * 100).toFixed(1));
+          const percentRemaining = parseFloat(((quota.quota_remaining / quota.entitlement) * 100).toFixed(1));
+          const fmtQuota = (n: number): string => String(parseFloat(n.toFixed(2)));
           const statusBadge = this._getStatusBadge(percentRemaining);
           const mood = this._getMood(percentRemaining);
           const isOverQuota = quota.remaining < 0;
@@ -1455,12 +1450,12 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
                 ? `<span class="stat-label" title="Amount over your monthly quota" style="color: var(--vscode-charts-red);">Over by:</span>
 								   <span class="stat-value" style="color: var(--vscode-charts-red);">${overageAmount}</span>`
                 : `<span class="stat-label" title="Calls available until the reset date">Remaining:</span>
-								   <span class="stat-value">${quota.remaining}</span>`
+								   <span class="stat-value">${fmtQuota(quota.quota_remaining)}</span>`
               }
 							</div>
 							<div class="stat">
 								<span class="stat-label" title="Calls made since the last reset">Used:</span>
-								<span class="stat-value">${used}</span>
+								<span class="stat-value">${fmtQuota(used)}</span>
 							</div>
 							<div class="stat">
 								<span class="stat-label" title="Total calls allowed in this period">Total:</span>
@@ -1984,7 +1979,9 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
 
     const isOverQuota = premiumQuota.remaining < 0;
     const overageAmount = isOverQuota ? Math.abs(premiumQuota.remaining) : 0;
-    
+    const used = premiumQuota.entitlement - premiumQuota.quota_remaining;
+    const fmtQuota = (n: number): string => String(parseFloat(n.toFixed(2)));
+
     // Clamp displayPercent for visual components (0-100 range)
     const rawDisplayPercent = progressBarMode === "used" ? percentUsed : percentRemaining;
     const displayPercent = Math.max(0, Math.min(100, rawDisplayPercent));
@@ -1998,8 +1995,8 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
       ? (isOverQuota
         ? `+${overageAmount}/${premiumQuota.entitlement}`
         : (progressBarMode === "used"
-          ? `${percentUsed}/${premiumQuota.entitlement}`
-          : `${premiumQuota.remaining}/${premiumQuota.entitlement}`))
+          ? `${fmtQuota(used)}/${premiumQuota.entitlement}`
+          : `${fmtQuota(premiumQuota.quota_remaining)}/${premiumQuota.entitlement}`))
       : "";
 
     // If visual indicator is disabled, return only name + quota (no style-specific formatting or percentage)


### PR DESCRIPTION
feat: fractional precision for usage count & percentage
   - Show single-digit precision in usage percentage in WebView & Statusbar, in parity with built-in copilot extension
   - Show double-digit precision in used requests in WebView & Statusbar, in parity with 'Premium request analytics' dashboard

fix:
   - Fixed Used count in Statusbar
   - Add sidebar icon (graph) to Insights view for improved UI
   - Add `test-vsix` npm script for local extension packaging and testing
   
 Fixes #13 