### PR TITLE
Add configurable background polling for Copilot quota data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,70 @@
 # Change Log
 
-# [Unreleased]
-
-### Added
-- **Regular Quota Polling**: Copilot quota data can now refresh automatically on a configurable interval so the footer widget stays current without manual refreshes.
-
 # [3.7.3] - 2026-03-16
 
 ### Changed
+
 - **Quota Card Ordering**: Quotas in the Insights view are now sorted so **Premium Interactions** appears first for faster visibility of the most important limit.
 
 # [3.7.1] - 2026-03-10
 
 ### Added
+
 - **Insights View Icon**: Added an icon for the Copilot Insights sidebar view for better discoverability in the activity UI.
 
 ### Changed
+
 - **Fractional Quota Precision**: Premium quota remaining, used values, and percentages now preserve fractional precision in the sidebar and status bar to better match GitHub Copilot's reported usage.
 
 # [3.7.0] - 2026-03-09
 
 ### Added
+
 - **JSON Clipboard Export**: Copy the raw Copilot Insights payload as formatted JSON directly from the sidebar.
 
 ## [3.6.0] - 2026-02-05
 
 ### Added
+
 - **Overage Cost Estimation**: Premium quota cards now show estimated overage cost when your plan allows usage beyond the included quota.
 - **Quota Exceeded Summary**: Over-quota states now show a focused summary with overage amount, total used, and reset timing.
 
 ### Changed
+
 - Improved overage messaging so permitted overages and blocked premium usage are easier to distinguish.
 
 # [3.5.0] - 2026-02-04
 
 ### Added
+
 - **Quota Usage Breakdown**: See a breakdown of premium usage by day and by organization.
 - **Advanced Error Reporting**: More detailed error messages and troubleshooting tips in the sidebar.
 - **Snapshot Export Improvements**: Export quota snapshots with timestamps for better tracking.
 - **Accessibility Enhancements**: Improved keyboard navigation and screen reader support in the sidebar view.
 
 ### Changed
+
 - UI polish for quota breakdown and error banners.
 - Minor performance improvements for sidebar refresh.
 
 ## [3.0.0] - 2026-01-28
 
 ### Added
+
 - **Weighted Prediction**: Estimates daily premium usage, with confidence level and exhaustion forecast.
 - **Burn Rate Analysis**: Detects if usage is accelerating, slowing, or stable, comparing recent and average burn rates.
 - **Visual Trend Chart**: Enhanced local quota history with a line chart and improved snapshot filtering.
 - **Sidebar & Status Bar Enhancements**: More real-time updates, better configuration handling, and improved error feedback.
 
 ### Changed
+
 - Smarter local quota history: improved filtering and more accurate comparisons.
 - UI/UX refinements and bug fixes for a smoother experience.
 
 ## [2.0.0] - 2026-01-13
 
 ### Added
+
 - **Local Snapshot History**: Track premium interactions over time with automatic snapshot recording
   - Stores up to 10 local snapshots of premium quota usage
   - Visual line chart showing premium interactions trend over time
@@ -71,40 +77,47 @@
   - Clear "Based on local refreshes" disclaimer
 
 ### Changed
+
 - Improved visual hierarchy with snapshot history section in a card layout
 - Enhanced chart formatting with relative time labels (e.g., "2h ago", "1d ago")
 
 ## [1.8.0] - 2026-01-12
 
 ### Added
+
 - Status bar customization settings for location and visual style
 - Multiple status bar style options: detailed, progress capsule, circular ring, solid bar, shaded bar, minimalist, and adaptive emoji
 - Ability to position status bar on left, right, or both sides
 - Granular control over status bar elements (name, numerical quota, visual indicator)
 
 ### Changed
+
 - Enhanced status bar configuration with more flexible display options
 - Improved visual feedback with multiple indicator styles
 
 ## [1.7.0] - 2026-01-09
 
 ### Added
+
 - Progress bar display mode setting: show **Remaining** (default) or **Used** quota in the quota progress bars.
 - Settings (gear) button in the Insights view title bar to open Copilot Insights settings.
 
 ## [1.6.0] - 2026-01-09
 
 ### Added
+
 - “What does this mean?” tooltips on key quota UI labels (e.g., Unlimited, Premium interactions, Reset Date, and other critical fields)
 - Optional “Quota mood” indicator (😌 / 🙂 / 😬 / 😱) to summarize quota risk at a glance
 - Daily capacity projections for common premium model multipliers (0.33x, 1x, 3x)
 
 ### Changed
+
 - Reset Date display now shows the date only (no time)
 
 ## [1.5.0]
 
 ### Added
+
 - "Copy Summary to Clipboard" button in the sidebar view
 - Export Copilot insights as formatted Markdown with all plan details, quotas, status badges, and organization information
 - One-click copy to clipboard functionality for easy sharing and documentation
@@ -112,6 +125,7 @@
 ## [1.4.0]
 
 ### Added
+
 - Status badges for quota health visualization:
   - 🟢 Healthy (>50% remaining)
   - 🟡 Watch (20-50% remaining)
@@ -121,39 +135,46 @@
 ## [1.3.1]
 
 ### Changed
+
 - Copilot plan names are normalized to start with an uppercase letter across the UI.
 
 ### Fixed
+
 - Premium usage warning resets correctly when a new billing cycle starts, preventing stale alerts.
 
 ## [1.2.0]
 
 ### Added
+
 - One-time warning when Premium requests exceed 85% of the monthly quota, with a quick link to open the Insights view.
 
 ## [1.0.1]
 
 ### Added
+
 - Section title "Projections premium requests before the reset" to better organize pacing guidance in quota cards.
 
 ## [1.0.0]
 
 ### Added
+
 - Sidebar webview (Copilot Insights) showing plan, access details, organizations, and quotas.
 - Quota cards for limited/unlimited quotas (progress bar + remaining/used/total).
 - Pacing guidance for quotas:
-	- Daily average to last until reset
-	- Weekly average (minimum 1 week)
-	- Workday average (Mon–Fri, approximate)
-	- Work hour average (Mon–Fri 9–5, approximate)
+  - Daily average to last until reset
+  - Weekly average (minimum 1 week)
+  - Workday average (Mon–Fri, approximate)
+  - Work hour average (Mon–Fri 9–5, approximate)
 - Status bar indicator for Premium Interactions (remaining/total + percent) with severity icons and tooltip.
 - Auto-refresh when the view becomes visible.
 - Refresh action in the view title bar.
 
 ### Changed
+
 - Improved sidebar layout and section ordering (Quotas at top; Plan Details and Organizations sections).
 - Moved “Last fetched” to the bottom of the view.
 
 ### Fixed
+
 - Correctly handle `quota_snapshots` returned as an object map (not an array).
 - Fixed weekly pacing calculation to avoid inflated values when less than one week remains.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,68 +3,57 @@
 # [3.7.3] - 2026-03-16
 
 ### Changed
-
 - **Quota Card Ordering**: Quotas in the Insights view are now sorted so **Premium Interactions** appears first for faster visibility of the most important limit.
 
 # [3.7.1] - 2026-03-10
 
 ### Added
-
 - **Insights View Icon**: Added an icon for the Copilot Insights sidebar view for better discoverability in the activity UI.
 
 ### Changed
-
 - **Fractional Quota Precision**: Premium quota remaining, used values, and percentages now preserve fractional precision in the sidebar and status bar to better match GitHub Copilot's reported usage.
 
 # [3.7.0] - 2026-03-09
 
 ### Added
-
 - **JSON Clipboard Export**: Copy the raw Copilot Insights payload as formatted JSON directly from the sidebar.
 
 ## [3.6.0] - 2026-02-05
 
 ### Added
-
 - **Overage Cost Estimation**: Premium quota cards now show estimated overage cost when your plan allows usage beyond the included quota.
 - **Quota Exceeded Summary**: Over-quota states now show a focused summary with overage amount, total used, and reset timing.
 
 ### Changed
-
 - Improved overage messaging so permitted overages and blocked premium usage are easier to distinguish.
 
 # [3.5.0] - 2026-02-04
 
 ### Added
-
 - **Quota Usage Breakdown**: See a breakdown of premium usage by day and by organization.
 - **Advanced Error Reporting**: More detailed error messages and troubleshooting tips in the sidebar.
 - **Snapshot Export Improvements**: Export quota snapshots with timestamps for better tracking.
 - **Accessibility Enhancements**: Improved keyboard navigation and screen reader support in the sidebar view.
 
 ### Changed
-
 - UI polish for quota breakdown and error banners.
 - Minor performance improvements for sidebar refresh.
 
 ## [3.0.0] - 2026-01-28
 
 ### Added
-
 - **Weighted Prediction**: Estimates daily premium usage, with confidence level and exhaustion forecast.
 - **Burn Rate Analysis**: Detects if usage is accelerating, slowing, or stable, comparing recent and average burn rates.
 - **Visual Trend Chart**: Enhanced local quota history with a line chart and improved snapshot filtering.
 - **Sidebar & Status Bar Enhancements**: More real-time updates, better configuration handling, and improved error feedback.
 
 ### Changed
-
 - Smarter local quota history: improved filtering and more accurate comparisons.
 - UI/UX refinements and bug fixes for a smoother experience.
 
 ## [2.0.0] - 2026-01-13
 
 ### Added
-
 - **Local Snapshot History**: Track premium interactions over time with automatic snapshot recording
   - Stores up to 10 local snapshots of premium quota usage
   - Visual line chart showing premium interactions trend over time
@@ -77,47 +66,40 @@
   - Clear "Based on local refreshes" disclaimer
 
 ### Changed
-
 - Improved visual hierarchy with snapshot history section in a card layout
 - Enhanced chart formatting with relative time labels (e.g., "2h ago", "1d ago")
 
 ## [1.8.0] - 2026-01-12
 
 ### Added
-
 - Status bar customization settings for location and visual style
 - Multiple status bar style options: detailed, progress capsule, circular ring, solid bar, shaded bar, minimalist, and adaptive emoji
 - Ability to position status bar on left, right, or both sides
 - Granular control over status bar elements (name, numerical quota, visual indicator)
 
 ### Changed
-
 - Enhanced status bar configuration with more flexible display options
 - Improved visual feedback with multiple indicator styles
 
 ## [1.7.0] - 2026-01-09
 
 ### Added
-
 - Progress bar display mode setting: show **Remaining** (default) or **Used** quota in the quota progress bars.
 - Settings (gear) button in the Insights view title bar to open Copilot Insights settings.
 
 ## [1.6.0] - 2026-01-09
 
 ### Added
-
 - “What does this mean?” tooltips on key quota UI labels (e.g., Unlimited, Premium interactions, Reset Date, and other critical fields)
 - Optional “Quota mood” indicator (😌 / 🙂 / 😬 / 😱) to summarize quota risk at a glance
 - Daily capacity projections for common premium model multipliers (0.33x, 1x, 3x)
 
 ### Changed
-
 - Reset Date display now shows the date only (no time)
 
 ## [1.5.0]
 
 ### Added
-
 - "Copy Summary to Clipboard" button in the sidebar view
 - Export Copilot insights as formatted Markdown with all plan details, quotas, status badges, and organization information
 - One-click copy to clipboard functionality for easy sharing and documentation
@@ -125,7 +107,6 @@
 ## [1.4.0]
 
 ### Added
-
 - Status badges for quota health visualization:
   - 🟢 Healthy (>50% remaining)
   - 🟡 Watch (20-50% remaining)
@@ -135,46 +116,39 @@
 ## [1.3.1]
 
 ### Changed
-
 - Copilot plan names are normalized to start with an uppercase letter across the UI.
 
 ### Fixed
-
 - Premium usage warning resets correctly when a new billing cycle starts, preventing stale alerts.
 
 ## [1.2.0]
 
 ### Added
-
 - One-time warning when Premium requests exceed 85% of the monthly quota, with a quick link to open the Insights view.
 
 ## [1.0.1]
 
 ### Added
-
 - Section title "Projections premium requests before the reset" to better organize pacing guidance in quota cards.
 
 ## [1.0.0]
 
 ### Added
-
 - Sidebar webview (Copilot Insights) showing plan, access details, organizations, and quotas.
 - Quota cards for limited/unlimited quotas (progress bar + remaining/used/total).
 - Pacing guidance for quotas:
-  - Daily average to last until reset
-  - Weekly average (minimum 1 week)
-  - Workday average (Mon–Fri, approximate)
-  - Work hour average (Mon–Fri 9–5, approximate)
+	- Daily average to last until reset
+	- Weekly average (minimum 1 week)
+	- Workday average (Mon–Fri, approximate)
+	- Work hour average (Mon–Fri 9–5, approximate)
 - Status bar indicator for Premium Interactions (remaining/total + percent) with severity icons and tooltip.
 - Auto-refresh when the view becomes visible.
 - Refresh action in the view title bar.
 
 ### Changed
-
 - Improved sidebar layout and section ordering (Quotas at top; Plan Details and Organizations sections).
 - Moved “Last fetched” to the bottom of the view.
 
 ### Fixed
-
 - Correctly handle `quota_snapshots` returned as an object map (not an array).
 - Fixed weekly pacing calculation to avoid inflated values when less than one week remains.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# [Unreleased]
+
+### Added
+- **Regular Quota Polling**: Copilot quota data can now refresh automatically on a configurable interval so the footer widget stays current without manual refreshes.
+
 # [3.7.3] - 2026-03-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It focuses on operational visibility, not team analytics. The extension helps an
 - Weighted prediction and burn-rate analysis for premium interactions.
 - Status bar indicator with configurable placement, style, and content.
 - One-click export to clipboard as Markdown or raw JSON.
-- Auto-refresh when the Insights view becomes visible, plus manual refresh and settings actions.
+- Configurable background polling, plus auto-refresh when the Insights view becomes visible.
 - Fractional precision for premium usage values and percentages so displayed numbers better match Copilot reporting.
 
 ## Screenshots
@@ -105,7 +105,7 @@ You can also package and install locally from a VSIX during development.
 2. Open the Copilot Insights icon in the VS Code activity bar.
 3. Sign in with GitHub if VS Code prompts for authentication.
 4. Review your plan details, quotas, and reset timing.
-5. Use the refresh button in the view title bar whenever you want a fresh snapshot.
+5. Leave background polling enabled for automatic updates, or use the refresh button whenever you want an immediate snapshot.
 
 ## Commands
 
@@ -121,6 +121,7 @@ Key settings:
 
 - `copilotInsights.showMood`: Show a mood indicator instead of the standard health status.
 - `copilotInsights.progressBarMode`: Choose `remaining` or `used` for quota bars.
+- `copilotInsights.pollingIntervalSeconds`: Refresh Copilot quota data automatically every `N` seconds. Set to `0` to disable polling.
 - `copilotInsights.statusBarLocation`: Choose `left`, `right`, or `both`.
 - `copilotInsights.statusBarStyle`: Select the status bar visual style.
 - `copilotInsights.statusBar.showName`: Toggle the `Copilot:` label.
@@ -131,6 +132,7 @@ Example:
 
 ```json
 {
+  "copilotInsights.pollingIntervalSeconds": 60,
   "copilotInsights.progressBarMode": "remaining",
   "copilotInsights.statusBarLocation": "right",
   "copilotInsights.statusBarStyle": "detailed-original"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "activationEvents": [
     "onStartupFinished"
   ],
+  "extensionKind": [
+    "ui"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,12 @@
           ],
           "description": "Controls how the progress bar displays quota: 'remaining' shows quota left (default), 'used' shows quota consumed."
         },
+        "copilotInsights.pollingIntervalSeconds": {
+          "type": "integer",
+          "default": 60,
+          "minimum": 0,
+          "description": "Refresh Copilot quota data automatically every N seconds. Set to 0 to disable background polling."
+        },
         "copilotInsights.statusBarLocation": {
           "type": "string",
           "default": "right",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,28 @@ interface LocalSnapshot {
 
 const SNAPSHOT_HISTORY_KEY = "copilotInsights.snapshotHistory";
 const MAX_SNAPSHOTS = 10;
+const DEFAULT_POLLING_INTERVAL_SECONDS = 60;
 
-class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
+export function normalizePollingIntervalSeconds(
+  value: number | undefined,
+  fallbackSeconds = DEFAULT_POLLING_INTERVAL_SECONDS
+): number {
+  const normalizedFallback = Number.isFinite(fallbackSeconds) && fallbackSeconds > 0
+    ? Math.round(fallbackSeconds)
+    : DEFAULT_POLLING_INTERVAL_SECONDS;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return normalizedFallback;
+  }
+
+  if (value <= 0) {
+    return 0;
+  }
+
+  return Math.max(1, Math.round(value));
+}
+
+class CopilotInsightsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = "copilotInsights.sidebarView";
   private _view?: vscode.WebviewView;
   private _statusBarItem: vscode.StatusBarItem;
@@ -52,6 +72,8 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
   private readonly _premiumUsageAlertKey =
     "copilotInsights.premiumUsageAlert.resetDate";
   private _snapshotHistory: LocalSnapshot[] = [];
+  private _pollingTimer?: ReturnType<typeof setInterval>;
+  private _isLoadingCopilotData = false;
 
   constructor(
     private readonly _extensionUri: vscode.Uri,
@@ -85,7 +107,7 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
     this._updateStatusBarVisibility();
 
     // Listen for configuration changes to update the status bar and sidebar in real-time
-    vscode.workspace.onDidChangeConfiguration((event) => {
+    const configurationChangeDisposable = vscode.workspace.onDidChangeConfiguration((event) => {
       const affectedVisual = event.affectsConfiguration('copilotInsights.statusBarLocation') ||
         event.affectsConfiguration('copilotInsights.statusBarStyle') ||
         event.affectsConfiguration('copilotInsights.progressBarMode') ||
@@ -93,13 +115,27 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
         event.affectsConfiguration('copilotInsights.statusBar.showNumericalQuota') ||
         event.affectsConfiguration('copilotInsights.statusBar.showVisualIndicator') ||
         event.affectsConfiguration('copilotInsights.showMood');
+      const affectedPolling = event.affectsConfiguration(
+        "copilotInsights.pollingIntervalSeconds"
+      );
+
+      if (event.affectsConfiguration("copilotInsights.statusBarLocation")) {
+        this._updateStatusBarVisibility();
+      }
 
       if (affectedVisual && this._lastData) {
         // Update the status bar and sidebar with the cached data
         this._updateStatusBar(this._lastData);
         this._updateWithData(this._lastData);
       }
+
+      if (affectedPolling) {
+        this._restartPolling(true);
+      }
     });
+    this._context.subscriptions.push(configurationChangeDisposable);
+
+    this._restartPolling();
   }
 
   // Getters to access status bar items for disposal
@@ -109,6 +145,48 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
 
   get bottomStatusBarItem(): vscode.StatusBarItem {
     return this._bottomStatusBarItem;
+  }
+
+  public dispose() {
+    this._clearPollingTimer();
+  }
+
+  private _restartPolling(refreshImmediately = false) {
+    this._clearPollingTimer();
+
+    const pollingIntervalSeconds = this._getPollingIntervalSeconds();
+    if (pollingIntervalSeconds === 0) {
+      return;
+    }
+
+    this._pollingTimer = setInterval(() => {
+      void this.loadCopilotData({ silent: true });
+    }, pollingIntervalSeconds * 1000);
+
+    if (refreshImmediately) {
+      void this.loadCopilotData({ silent: true });
+    }
+  }
+
+  private _clearPollingTimer() {
+    if (this._pollingTimer) {
+      clearInterval(this._pollingTimer);
+      this._pollingTimer = undefined;
+    }
+  }
+
+  private _getPollingIntervalSeconds(): number {
+    const configuredValue = vscode.workspace
+      .getConfiguration("copilotInsights")
+      .get<number>(
+        "pollingIntervalSeconds",
+        DEFAULT_POLLING_INTERVAL_SECONDS
+      );
+
+    return normalizePollingIntervalSeconds(
+      configuredValue,
+      DEFAULT_POLLING_INTERVAL_SECONDS
+    );
   }
 
   private _updateStatusBarVisibility() {
@@ -185,17 +263,25 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
     this.loadCopilotData();
   }
 
-  public async loadCopilotData() {
+  public async loadCopilotData(options: { silent?: boolean } = {}) {
+    if (this._isLoadingCopilotData) {
+      return;
+    }
+
+    this._isLoadingCopilotData = true;
+
     try {
       // Get GitHub authentication session
       const session = await vscode.authentication.getSession(
         "github",
         ["user:email"],
-        { createIfNone: true }
+        { createIfNone: !options.silent }
       );
 
       if (!session) {
-        this._updateWithError("Failed to authenticate with GitHub");
+        if (!options.silent) {
+          this._updateWithError("Failed to authenticate with GitHub");
+        }
         return;
       }
 
@@ -243,10 +329,20 @@ class CopilotInsightsViewProvider implements vscode.WebviewViewProvider {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error occurred";
+
+      if (options.silent) {
+        console.warn(
+          `Copilot Insights background refresh failed: ${errorMessage}`
+        );
+        return;
+      }
+
       this._updateWithError(errorMessage);
       vscode.window.showErrorMessage(
         `Failed to load Copilot data: ${errorMessage}`
       );
+    } finally {
+      this._isLoadingCopilotData = false;
     }
   }
 
@@ -2139,6 +2235,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.extensionUri,
     context
   );
+  context.subscriptions.push(provider);
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(
       CopilotInsightsViewProvider.viewType,
@@ -2202,6 +2299,11 @@ export function activate(context: vscode.ExtensionContext) {
         await config.update("statusBarStyle", "detailed-original", vscode.ConfigurationTarget.Global);
         await config.update("statusBarLocation", "right", vscode.ConfigurationTarget.Global);
         await config.update("progressBarMode", "remaining", vscode.ConfigurationTarget.Global);
+        await config.update(
+          "pollingIntervalSeconds",
+          DEFAULT_POLLING_INTERVAL_SECONDS,
+          vscode.ConfigurationTarget.Global
+        );
 
         vscode.window.showInformationMessage("Copilot Insights settings reset to defaults.");
         // Refresh the display

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,15 +1,23 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { normalizePollingIntervalSeconds } from "../extension";
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+suite("Extension Test Suite", () => {
+  test("normalizes valid polling intervals", () => {
+    assert.strictEqual(normalizePollingIntervalSeconds(undefined), 60);
+    assert.strictEqual(normalizePollingIntervalSeconds(60), 60);
+    assert.strictEqual(normalizePollingIntervalSeconds(0), 0);
+    assert.strictEqual(normalizePollingIntervalSeconds(-15), 0);
+    assert.strictEqual(normalizePollingIntervalSeconds(1.4), 1);
+    assert.strictEqual(normalizePollingIntervalSeconds(1.6), 2);
+  });
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  test("falls back when the configured interval is invalid", () => {
+    assert.strictEqual(normalizePollingIntervalSeconds(Number.NaN), 60);
+    assert.strictEqual(
+      normalizePollingIntervalSeconds(Number.POSITIVE_INFINITY),
+      60
+    );
+    assert.strictEqual(normalizePollingIntervalSeconds(undefined, 120), 120);
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds configurable background polling so Copilot quota data stays fresh without requiring manual refreshes.
Closes #15 

## What Changed

- add `copilotInsights.pollingIntervalSeconds` with a default of 60 seconds and support `0` to disable polling
- start or restart the polling timer on activation and whenever the setting changes
- make background refreshes silent by avoiding auth prompts and error toasts during polling
- prevent overlapping background fetches
- register the extension as `ui` and include the new polling setting in "Reset to Defaults"
- add unit tests for polling interval normalization

## Why

The extension already refreshes when the Insights view becomes visible or when the user triggers a manual refresh. Background polling keeps the sidebar and status bar more up to date while still letting users tune the interval or disable it entirely.

## Testing

- add test coverage for `normalizePollingIntervalSeconds`